### PR TITLE
Add to_undirected ops for directed graphs

### DIFF
--- a/crates/builder/benches/csr.rs
+++ b/crates/builder/benches/csr.rs
@@ -1,4 +1,5 @@
 use criterion::*;
+use graph_builder::graph::csr::Csr;
 use graph_builder::prelude::*;
 
 mod common;
@@ -38,6 +39,8 @@ fn from_edge_list(c: &mut Criterion) {
     group.finish();
 }
 
+type C = Csr<usize, usize, ()>;
+
 fn bench_from_edge_list(
     b: &mut criterion::Bencher,
     Input {
@@ -51,14 +54,7 @@ fn bench_from_edge_list(
     let edges: Vec<(usize, usize, ())> = uniform_edge_list(node_count, edge_count, |_, _| ());
     b.iter_batched(
         || EdgeList::new(edges.clone()),
-        |mut edge_list| {
-            black_box(Csr::from((
-                &mut edge_list,
-                node_count,
-                direction,
-                csr_layout,
-            )))
-        },
+        |edge_list| black_box(C::from((&edge_list, node_count, direction, csr_layout))),
         criterion::BatchSize::SmallInput,
     )
 }

--- a/crates/builder/src/graph/csr.rs
+++ b/crates/builder/src/graph/csr.rs
@@ -453,10 +453,9 @@ where
 
     type EV = EV;
 
-    type EdgeIter<'a>
+    type EdgeIter<'a> = impl ParallelIterator<Item = (Self::NI, Self::NI, Self::EV)>
     where
-        Self: 'a,
-    = impl ParallelIterator<Item = (Self::NI, Self::NI, Self::EV)>;
+        Self: 'a;
 
     fn edges(&self) -> Self::EdgeIter<'_> {
         (0..self.g.node_count().index())

--- a/crates/builder/src/input/dotgraph.rs
+++ b/crates/builder/src/input/dotgraph.rs
@@ -279,7 +279,7 @@ where
 mod tests {
     use std::path::PathBuf;
 
-    use crate::input::InputPath;
+    use crate::input::{edgelist::Edges, InputPath};
 
     use super::*;
 

--- a/crates/builder/src/input/edgelist.rs
+++ b/crates/builder/src/input/edgelist.rs
@@ -116,10 +116,9 @@ impl<NI: Idx, EV: Copy + Send + Sync> Edges for EdgeList<NI, EV> {
 
     type EV = EV;
 
-    type EdgeIter<'a>
+    type EdgeIter<'a> = rayon::iter::Copied<rayon::slice::Iter<'a, (Self::NI, Self::NI, Self::EV)>>
     where
-        Self: 'a,
-    = rayon::iter::Copied<rayon::slice::Iter<'a, (Self::NI, Self::NI, Self::EV)>>;
+        Self: 'a;
 
     fn edges(&self) -> Self::EdgeIter<'_> {
         self.list.into_par_iter().copied()

--- a/crates/builder/src/input/edgelist.rs
+++ b/crates/builder/src/input/edgelist.rs
@@ -43,20 +43,56 @@ impl<NI: Idx, EV> InputCapabilities<NI> for EdgeListInput<NI, EV> {
     type GraphInput = EdgeList<NI, EV>;
 }
 
+#[allow(clippy::len_without_is_empty)]
+pub trait Edges {
+    type NI: Idx;
+    type EV;
+
+    type EdgeIter<'a>: ParallelIterator<Item = (Self::NI, Self::NI, Self::EV)>
+    where
+        Self: 'a;
+
+    fn edges(&self) -> Self::EdgeIter<'_>;
+
+    fn max_node_id(&self) -> Self::NI {
+        default_max_node_id(self)
+    }
+
+    fn degrees(&self, node_count: Self::NI, direction: Direction) -> Vec<Atomic<Self::NI>> {
+        let mut degrees = Vec::with_capacity(node_count.index());
+        degrees.resize_with(node_count.index(), || Atomic::new(Self::NI::zero()));
+
+        if matches!(direction, Direction::Outgoing | Direction::Undirected) {
+            self.edges().for_each(|(s, _, _)| {
+                Self::NI::get_and_increment(&degrees[s.index()], AcqRel);
+            });
+        }
+
+        if matches!(direction, Direction::Incoming | Direction::Undirected) {
+            self.edges().for_each(|(_, t, _)| {
+                Self::NI::get_and_increment(&degrees[t.index()], AcqRel);
+            });
+        }
+
+        degrees
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize;
+}
+
+fn default_max_node_id<E: Edges + ?Sized>(edges: &E) -> E::NI {
+    edges
+        .edges()
+        .into_par_iter()
+        .map(|(s, t, _)| E::NI::max(s, t))
+        .reduce(E::NI::zero, E::NI::max)
+}
+
 #[derive(Debug)]
 pub struct EdgeList<NI: Idx, EV> {
     list: Box<[(NI, NI, EV)]>,
     max_node_id: Option<NI>,
-}
-
-impl<NI: Idx, EV> EdgeList<NI, EV> {
-    pub(crate) fn edges(&self) -> &[(NI, NI, EV)] {
-        &self.list
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        self.list.len()
-    }
 }
 
 impl<NI: Idx, EV: Sync> EdgeList<NI, EV> {
@@ -73,35 +109,32 @@ impl<NI: Idx, EV: Sync> EdgeList<NI, EV> {
             max_node_id: Some(max_node_id),
         }
     }
+}
 
-    pub fn max_node_id(&self) -> NI {
-        match self.max_node_id {
-            Some(id) => id,
-            None => self
-                .edges()
-                .par_iter()
-                .map(|(s, t, _)| NI::max(*s, *t))
-                .reduce(NI::zero, NI::max),
-        }
+impl<NI: Idx, EV: Copy + Send + Sync> Edges for EdgeList<NI, EV> {
+    type NI = NI;
+
+    type EV = EV;
+
+    type EdgeIter<'a>
+    where
+        Self: 'a,
+    = rayon::iter::Copied<rayon::slice::Iter<'a, (Self::NI, Self::NI, Self::EV)>>;
+
+    fn edges(&self) -> Self::EdgeIter<'_> {
+        self.list.into_par_iter().copied()
     }
 
-    pub fn degrees(&self, node_count: NI, direction: Direction) -> Vec<Atomic<NI>> {
-        let mut degrees = Vec::with_capacity(node_count.index());
-        degrees.resize_with(node_count.index(), || Atomic::new(NI::zero()));
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.list.len()
+    }
 
-        if matches!(direction, Direction::Outgoing | Direction::Undirected) {
-            self.edges().par_iter().for_each(|(s, _, _)| {
-                NI::get_and_increment(&degrees[s.index()], AcqRel);
-            });
+    fn max_node_id(&self) -> Self::NI {
+        match self.max_node_id {
+            Some(id) => id,
+            None => default_max_node_id(self),
         }
-
-        if matches!(direction, Direction::Incoming | Direction::Undirected) {
-            self.edges().par_iter().for_each(|(_, t, _)| {
-                NI::get_and_increment(&degrees[t.index()], AcqRel);
-            });
-        }
-
-        degrees
     }
 }
 

--- a/crates/builder/src/input/mod.rs
+++ b/crates/builder/src/input/mod.rs
@@ -11,6 +11,7 @@ pub use dotgraph::DotGraph;
 pub use dotgraph::DotGraphInput;
 pub use edgelist::EdgeList;
 pub use edgelist::EdgeListInput;
+pub use edgelist::Edges;
 pub use graph500::Graph500;
 pub use graph500::Graph500Input;
 

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -1,9 +1,11 @@
-#![feature(slice_partition_dedup)]
+#![feature(doc_cfg)]
+#![feature(generic_associated_types)]
 #![feature(maybe_uninit_write_slice)]
 #![feature(maybe_uninit_slice)]
-#![feature(step_trait)]
 #![feature(new_uninit)]
-#![feature(doc_cfg)]
+#![feature(slice_partition_dedup)]
+#![feature(step_trait)]
+#![feature(type_alias_impl_trait)]
 #![allow(dead_code)]
 
 //! A library that can be used as a building block for high-performant graph

--- a/crates/builder/src/prelude.rs
+++ b/crates/builder/src/prelude.rs
@@ -13,6 +13,7 @@ pub use crate::graph_ops::InDegreePartitionOp;
 pub use crate::graph_ops::OutDegreePartitionOp;
 pub use crate::graph_ops::RelabelByDegreeOp;
 pub use crate::graph_ops::SerializeGraphOp;
+pub use crate::graph_ops::ToUndirectedOp;
 
 pub use crate::index::Idx;
 pub use atomic::Atomic;


### PR DESCRIPTION
While `to_undirected` is provided by a trait, only the `DirectedCsrGraph`
can actually implement in because we need to create a copy of the NodeValues
and those are private.

We can add an `impl Clone for NodeValues` later to allow for a more generic impl.

Another, admittedly bigger change is the introduction of the `Edges` trait that is
being used in the `From<E> for Csr` impls. That is, building a Graph is generic
over the edge list type, as long as it can provide a parallel iterator over its values.

The `to_undirected` impls makes use of that by not building an edgelist upfron. Instead,
the Graph construction methods will get their data directly from the existing CSR, also in parallel.
This should reduce memory usage during calls to `to_undirected` as we don't need a
third copy of the graph in memory.

This change is not yet propagated to the GraphBuilder, but we can do this in a later PR.

We actually need two intersting features to enable the Edges trait as it is:
[`generic_associated_types` (GAT)](https://rust-lang.github.io/rfcs/1598-generic_associated_types.html) and [`type_alias_impl_trait`](https://rust-lang.github.io/rfcs/2515-type_alias_impl_trait.html).

GATs are required because we need to return an iterator that might borrow from self
during the time that `edges` is being used.

The type alias impl trait is required because we need to return some concrete type
as the parallel iterator for the edges. We could not sepcify the type because it
would require as to write some `F` for a closure but closures cannot be named in this way.

