### PR TITLE
Link to libpython by default

### DIFF
--- a/crates/unladen_swallow/Cargo.toml
+++ b/crates/unladen_swallow/Cargo.toml
@@ -17,6 +17,10 @@ publish = false
 name = "unladen_swallow"
 crate-type = ["cdylib"]
 
+[features]
+default = []
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
 graph = { path = "../algos", version = "^0.2.0" }
 log = "0.4.14"
@@ -25,5 +29,5 @@ pyo3-log = "0.6.0"
 
 [dependencies.pyo3]
 version = "0.16.0"
-features = ["extension-module", "macros", "pyproto", "auto-initialize"]
+features = ["macros", "pyproto", "auto-initialize"]
 default-features = false

--- a/crates/unladen_swallow/README.md
+++ b/crates/unladen_swallow/README.md
@@ -27,20 +27,20 @@ source .env/bin/activate
 Build in debug mode.
 
 ```
-maturin develop
+maturin develop --cargo-extra-args="--features=extension-module"
 ```
 
 Build in release mode.
 
 ```
-maturin develop --release
+maturin develop --release --cargo-extra-args="--features=extension-module"
 ```
 
 Rebuild the extension in release mode 2 seconds after the last file change.
 This is an optional step.
 
 ```
-cargo watch --shell 'maturin develop --release' --delay 2
+cargo watch --shell 'maturin develop --release --cargo-extra-args="--features=extension-module"' --delay 2
 ```
 
 ### Testing

--- a/crates/unladen_swallow/src/graphs/mod.rs
+++ b/crates/unladen_swallow/src/graphs/mod.rs
@@ -65,7 +65,7 @@ impl<NI, G> PyGraph<NI, G> {
     }
 
     fn g(&self) -> &G {
-        &*self.g
+        &self.g
     }
 }
 


### PR DESCRIPTION
Fixes broken `cargo build` from the workspace root on arm64 architecture
