### PR TITLE
Apply clippy suggestions

### DIFF
--- a/crates/builder/src/graph/csr.rs
+++ b/crates/builder/src/graph/csr.rs
@@ -669,7 +669,7 @@ where
     type Error = Error;
 
     fn try_from((path, _): (PathBuf, CsrLayout)) -> Result<Self, Self::Error> {
-        let reader = BufReader::new(File::open(&path)?);
+        let reader = BufReader::new(File::open(path)?);
         let graph = DirectedCsrGraph::deserialize(reader)?;
 
         Ok(graph)
@@ -866,7 +866,7 @@ where
     type Error = Error;
 
     fn try_from((path, _): (PathBuf, CsrLayout)) -> Result<Self, Self::Error> {
-        let reader = BufReader::new(File::open(&path)?);
+        let reader = BufReader::new(File::open(path)?);
         UndirectedCsrGraph::deserialize(reader)
     }
 }

--- a/crates/builder/src/input/gdl.rs
+++ b/crates/builder/src/input/gdl.rs
@@ -100,7 +100,7 @@ where
             let id = node.id();
             let label = node.labels().next().expect("Single label expected");
             let degree = degree(gdl_graph, node);
-            let _ = writeln!(nodes_string, "v {} {} {}", id, &label[1..], degree);
+            let _ = writeln!(nodes_string, "v {id} {} {degree}", &label[1..]);
         }
 
         let mut rels_string = String::from("");
@@ -117,10 +117,10 @@ where
                 .get_node(rel.target())
                 .expect("Target expected")
                 .id();
-            let _ = writeln!(rels_string, "e {} {}", source_id, target_id);
+            let _ = writeln!(rels_string, "e {source_id} {target_id}");
         }
 
-        let input = format!("{}\n{}{}", header, nodes_string, rels_string);
+        let input = format!("{header}\n{nodes_string}{rels_string}");
         let reader = LineReader::new(input.as_bytes());
 
         DotGraph::<NI, Label>::try_from(reader).expect("GDL to .graph conversion failed")

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -526,5 +526,5 @@ async fn compute_wcc(
 }
 
 fn from_arrow_err(e: ArrowError) -> Status {
-    Status::internal(format!("ArrowError: {:?}", e))
+    Status::internal(format!("ArrowError: {e:?}"))
 }

--- a/crates/unladen_swallow/src/graphs/mod.rs
+++ b/crates/unladen_swallow/src/graphs/mod.rs
@@ -236,7 +236,7 @@ where
     }
 
     fn __repr__(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 

--- a/crates/unladen_swallow/src/page_rank.rs
+++ b/crates/unladen_swallow/src/page_rank.rs
@@ -69,6 +69,6 @@ impl PageRankResult {
     }
 
     fn __repr__(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }

--- a/crates/unladen_swallow/src/wcc.rs
+++ b/crates/unladen_swallow/src/wcc.rs
@@ -82,6 +82,6 @@ impl WccResult {
     }
 
     fn __repr__(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }


### PR DESCRIPTION
- Remove taking a ref on paths that are already refs
- Use variables directly in format strings
