### PR TITLE
Remove type_alias_impl_trait feature

### DIFF
--- a/crates/builder/build.rs
+++ b/crates/builder/build.rs
@@ -19,8 +19,21 @@ pub fn test() {
 }
 "#;
 
+// Checks if the new_uninit feature can be enabled
+const NEW_UNINIT_PROBE: &str = r#"
+#![feature(new_uninit)]
+#![allow(dead_code)]
+
+use std::mem::MaybeUninit;
+
+pub fn test() -> Box<[MaybeUninit<usize>]> {
+    Box::<[usize]>::new_uninit_slice(42)
+}
+"#;
+
 fn main() {
     test_for_feature("maybe_uninit_write_slice", MAYBE_UNINIT_WRITE_SLICE_PROBE);
+    test_for_feature("new_uninit", NEW_UNINIT_PROBE);
 }
 
 fn test_for_feature(feature_name: &str, probe: &str) {

--- a/crates/builder/src/graph/csr.rs
+++ b/crates/builder/src/graph/csr.rs
@@ -329,20 +329,20 @@ where
 
         let [node_count, edge_count] = meta;
 
-        let mut offsets = Box::<[NI]>::new_uninit_slice(node_count.index() + 1);
+        let mut offsets = Box::new_uninit_slice_compat(node_count.index() + 1);
         let offsets_ptr = offsets.as_mut_ptr() as *mut NI;
         let offsets_ptr =
             unsafe { std::slice::from_raw_parts_mut(offsets_ptr, node_count.index() + 1) };
         read.read_exact(offsets_ptr.as_mut_byte_slice())?;
 
-        let mut targets = Box::<[Target<NI, EV>]>::new_uninit_slice(edge_count.index());
+        let mut targets = Box::new_uninit_slice_compat(edge_count.index());
         let targets_ptr = targets.as_mut_ptr() as *mut Target<NI, EV>;
         let targets_ptr =
             unsafe { std::slice::from_raw_parts_mut(targets_ptr, edge_count.index()) };
         read.read_exact(targets_ptr.as_mut_byte_slice())?;
 
-        let offsets = unsafe { offsets.assume_init() };
-        let targets = unsafe { targets.assume_init() };
+        let offsets = unsafe { offsets.assume_init_compat() };
+        let targets = unsafe { targets.assume_init_compat() };
 
         Ok(Csr::new(offsets, targets))
     }
@@ -384,13 +384,13 @@ where
         read.read_exact(meta.as_mut_byte_slice())?;
         let [node_count] = meta;
 
-        let mut node_values = Box::<[NV]>::new_uninit_slice(node_count);
+        let mut node_values = Box::new_uninit_slice_compat(node_count);
         let node_values_ptr = node_values.as_mut_ptr() as *mut NV;
         let node_values_slice =
             unsafe { std::slice::from_raw_parts_mut(node_values_ptr, node_count.index()) };
         read.read_exact(node_values_slice.as_mut_byte_slice())?;
 
-        let offsets = unsafe { node_values.assume_init() };
+        let offsets = unsafe { node_values.assume_init_compat() };
 
         Ok(NodeValues(offsets))
     }

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(doc_cfg)]
 #![feature(slice_partition_dedup)]
 #![feature(step_trait)]
-#![feature(type_alias_impl_trait)]
 #![allow(dead_code)]
 
 //! A library that can be used as a building block for high-performant graph

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(has_maybe_uninit_write_slice, feature(maybe_uninit_write_slice))]
+#![cfg_attr(has_new_uninit, feature(new_uninit))]
 #![feature(doc_cfg)]
-#![feature(new_uninit)]
 #![feature(slice_partition_dedup)]
 #![feature(step_trait)]
 #![feature(type_alias_impl_trait)]


### PR DESCRIPTION
 I'm not entirely sure if this is ok or if the drive_unindexed method is called multiple times
but looking at existing implementations like [flat_map](https://github.com/rayon-rs/rayon/blob/4d36131d047db5906c04b986120af56224321a62/src/iter/flat_map.rs#L39-L45)
and the [design doc](https://github.com/rayon-rs/rayon/blob/4d36131d047db5906c04b986120af56224321a62/src/iter/plumbing/README.md) seem to suggest it is.

Based on #66.
