### PR TITLE
Improve dotgraph label stats computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ atomic_float = "0.1.0"
 byte-slice-cast = "1.2.2"
 clap = { version = "4.0", features = ["derive"] }
 criterion = { version = "0.4.0", features = ["html_reports"] }
+dashmap = "5.4.0"
 delegate = "0.8.0"
 env_logger = "0.9.3"
 fast-float = "0.2.0"

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -45,5 +45,9 @@ harness = false
 name = "csr"
 harness = false
 
+[[bench]]
+name = "dotgraph"
+harness = false
+
 [package.metadata.docs.rs]
 features = ["gdl", "dotgraph"]

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 atoi.workspace = true
 atomic.workspace = true
 byte-slice-cast.workspace = true
+dashmap.workspace = true
 delegate.workspace = true
 fast-float.workspace = true
 fxhash.workspace = true

--- a/crates/builder/benches/common/gen.rs
+++ b/crates/builder/benches/common/gen.rs
@@ -21,3 +21,14 @@ where
         })
         .collect::<Vec<_>>()
 }
+
+pub fn node_values<NV, F>(node_count: usize, node_value: F) -> Vec<NV>
+where
+    F: Fn(usize, &mut StdRng) -> NV,
+{
+    let mut rng = StdRng::seed_from_u64(42);
+
+    (0..node_count)
+        .map(|n| node_value(n, &mut rng))
+        .collect::<Vec<_>>()
+}

--- a/crates/builder/benches/dotgraph.rs
+++ b/crates/builder/benches/dotgraph.rs
@@ -1,0 +1,37 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use graph_builder::prelude::*;
+
+mod common;
+
+use common::*;
+use graph_builder::input::dotgraph::{LabelStats, NodeLabelIndex};
+use rand::Rng;
+
+fn node_label_index(c: &mut Criterion) {
+    let mut group = c.benchmark_group("node_label_index");
+    group.sampling_mode(SamplingMode::Flat);
+
+    group.bench_function(SMALL.name, |b| bench_node_label_index(b, SMALL));
+    group.bench_function(MEDIUM.name, |b| bench_node_label_index(b, MEDIUM));
+    group.bench_function(LARGE.name, |b| bench_node_label_index(b, LARGE));
+
+    group.finish();
+}
+
+fn bench_node_label_index(b: &mut criterion::Bencher, Input { node_count, .. }: Input) {
+    let labels = common::gen::node_values(node_count, |_node, rng| rng.gen_range(0..42));
+    let graph: UndirectedCsrGraph<usize, usize> = GraphBuilder::new()
+        .edges([(0, node_count - 1)])
+        .node_values(labels.clone())
+        .build();
+    let stats = LabelStats::from_graph(&graph);
+
+    b.iter(|| {
+        black_box(NodeLabelIndex::from_stats(node_count, &stats, |node| {
+            labels[node]
+        }))
+    })
+}
+
+criterion_group!(benches, node_label_index);
+criterion_main!(benches);

--- a/crates/builder/benches/dotgraph.rs
+++ b/crates/builder/benches/dotgraph.rs
@@ -7,6 +7,28 @@ use common::*;
 use graph_builder::input::dotgraph::{LabelStats, NodeLabelIndex};
 use rand::Rng;
 
+fn label_stats(c: &mut Criterion) {
+    let mut group = c.benchmark_group("label_stats");
+
+    group.sampling_mode(SamplingMode::Flat);
+
+    group.bench_function(SMALL.name, |b| bench_label_stats(b, SMALL));
+    group.bench_function(MEDIUM.name, |b| bench_label_stats(b, MEDIUM));
+    group.bench_function(LARGE.name, |b| bench_label_stats(b, LARGE));
+
+    group.finish();
+}
+
+fn bench_label_stats(b: &mut criterion::Bencher, Input { node_count, .. }: Input) {
+    let labels = common::gen::node_values(node_count, |_node, rng| rng.gen_range(0..42));
+    let graph: UndirectedCsrGraph<usize, usize> = GraphBuilder::new()
+        .edges([(0, node_count - 1)])
+        .node_values(labels.clone())
+        .build();
+
+    b.iter(|| black_box(LabelStats::from_graph(&graph)))
+}
+
 fn node_label_index(c: &mut Criterion) {
     let mut group = c.benchmark_group("node_label_index");
     group.sampling_mode(SamplingMode::Flat);

--- a/crates/builder/benches/dotgraph.rs
+++ b/crates/builder/benches/dotgraph.rs
@@ -55,5 +55,5 @@ fn bench_node_label_index(b: &mut criterion::Bencher, Input { node_count, .. }: 
     })
 }
 
-criterion_group!(benches, node_label_index);
+criterion_group!(benches, label_stats, node_label_index);
 criterion_main!(benches);

--- a/crates/builder/src/input/dotgraph.rs
+++ b/crates/builder/src/input/dotgraph.rs
@@ -446,7 +446,7 @@ where
     NI: Idx,
     Label: Idx,
 {
-    pub fn from_stats<F>(node_count: NI, label_stats: LabelStats<NI, Label>, label_func: F) -> Self
+    pub fn from_stats<F>(node_count: NI, label_stats: &LabelStats<NI, Label>, label_func: F) -> Self
     where
         Label: Hash,
         F: Fn(NI) -> Label + Send + Sync,
@@ -459,13 +459,13 @@ where
     }
 }
 
-impl<Label, NI, F> From<(NI, LabelStats<NI, Label>, F)> for NodeLabelIndex<Label, NI>
+impl<Label, NI, F> From<(NI, &LabelStats<NI, Label>, F)> for NodeLabelIndex<Label, NI>
 where
     NI: Idx,
     Label: Idx + Hash,
     F: Fn(NI) -> Label + Send + Sync,
 {
-    fn from((node_count, label_stats, label_func): (NI, LabelStats<NI, Label>, F)) -> Self {
+    fn from((node_count, label_stats, label_func): (NI, &LabelStats<NI, Label>, F)) -> Self {
         let LabelStats {
             label_count,
             max_label,
@@ -480,7 +480,7 @@ where
         offsets.push(Label::zero());
 
         let mut total = Label::zero();
-        for label in Label::zero().range_inclusive(max_label) {
+        for label in Label::zero().range_inclusive(*max_label) {
             offsets.push(total);
             total += Label::new(*label_frequency.get(&label).unwrap_or(&0));
         }
@@ -623,7 +623,7 @@ mod tests {
         let graph = UndirectedCsrGraph::<usize, usize>::from((graph, CsrLayout::Sorted));
         let label_stats = LabelStats::from_graph(&graph);
 
-        let idx = NodeLabelIndex::from_stats(graph.node_count(), label_stats, |node| {
+        let idx = NodeLabelIndex::from_stats(graph.node_count(), &label_stats, |node| {
             *graph.node_value(node)
         });
 

--- a/crates/builder/src/input/dotgraph.rs
+++ b/crates/builder/src/input/dotgraph.rs
@@ -7,13 +7,11 @@ use std::{
     mem::ManuallyDrop,
     ops::Range,
     path::Path,
-    sync::{
-        atomic::{AtomicUsize, Ordering::Acquire},
-        Arc, Mutex,
-    },
+    sync::atomic::{AtomicUsize, Ordering::Acquire},
 };
 
 use atomic::Atomic;
+use dashmap::DashMap;
 use fxhash::FxHashMap;
 use linereader::LineReader;
 use rayon::prelude::*;
@@ -256,7 +254,7 @@ where
         + Sync,
 {
     fn from(graph: &G) -> Self {
-        let label_frequency = Arc::new(Mutex::new(FxHashMap::default()));
+        let label_frequency: DashMap<Label, usize> = DashMap::new();
         let max_degree = AtomicUsize::new(usize::MIN);
         let max_label = AtomicUsize::new(usize::MIN);
 
@@ -269,7 +267,6 @@ where
         })
         .into_par_iter()
         .for_each(|range: Range<usize>| {
-            let mut local_frequency = FxHashMap::default();
             let mut local_max_degree = NI::new(usize::MIN);
             let mut local_max_label = Label::new(usize::MIN);
 
@@ -277,7 +274,7 @@ where
                 let node = NI::new(node);
                 let label = graph.node_value(node);
 
-                let frequency = local_frequency.entry(*label).or_insert_with(|| {
+                let mut frequency = label_frequency.entry(*label).or_insert_with(|| {
                     if *label > local_max_label {
                         local_max_label = *label;
                     }
@@ -290,26 +287,19 @@ where
 
             update_max_value(local_max_label.index(), &max_label);
             update_max_value(local_max_degree.index(), &max_degree);
-
-            {
-                let mut label_frequency = label_frequency.lock().unwrap();
-                local_frequency.into_iter().for_each(|(k, v)| {
-                    let freq = label_frequency.entry(k).or_insert(0);
-                    *freq += v;
-                });
-            }
         });
 
         let max_degree = NI::new(max_degree.load(atomic::Ordering::Acquire));
         let max_label = Label::new(max_label.load(atomic::Ordering::Acquire));
-
-        let label_frequency = Arc::try_unwrap(label_frequency)
-            .expect("Lock still has multiple owners")
-            .into_inner()
-            .expect("Mutex must not be locked");
-
-        let max_label_frequency = label_frequency.values().max().copied().unwrap_or_default();
+        let max_label_frequency = label_frequency
+            .iter()
+            .map(|ref_multi| *ref_multi.value())
+            .max()
+            .unwrap_or_default();
         let label_count = label_frequency.len();
+        let label_frequency = label_frequency
+            .into_iter()
+            .collect::<FxHashMap<Label, usize>>();
 
         Self {
             max_degree,


### PR DESCRIPTION
```
label_stats/small       time:   [140.35 µs 143.00 µs 145.80 µs]
                        change: [-78.799% -78.216% -77.606%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
label_stats/medium      time:   [603.23 µs 615.10 µs 627.29 µs]
                        change: [-80.182% -79.663% -79.083%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
label_stats/large       time:   [4.5502 ms 4.6202 ms 4.6917 ms]
                        change: [-34.855% -33.537% -32.361%] (p = 0.00 < 0.05)
                        Performance has improved.
```
